### PR TITLE
maintain XHTML 1.0 strict with blank author

### DIFF
--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -1,5 +1,7 @@
 {{if .Params.author}}
-  <p>by {{.Params.author}}{{else}}{{ .Site.Params.author }}</p>
+  <p>by {{.Params.author}}</p>
+{{else if .Site.Params.author}}
+  <p>by {{.Site.Params.author}}</p>
 {{end}}
 
 {{ if not .Date.IsZero }}


### PR DESCRIPTION
When a post does not have an author and when the author is not defined under `.Site.Params.author` a `</p>` tag without the opening `<p>` tag is put inside the post. This causes the XHTML 1.0 strict validation at [https://validator.w3.org/check](https://validator.w3.org/check) to fail for the post. 
I have modified the `/layouts/partials/metadata.html` file to not print anything if there is no author and to first fallback to `.Site.Params.author` if the post has no author. Let me know if this is the intended behavior.
Otherwise, thanks for making this great Hugo theme!