### PR TITLE
add footer links to email, RSS, and socials

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,3 +14,17 @@ enableRobotsTXT = true
     name = "Posts"
     url = "/posts/"
     weight = 2
+
+[params]
+	author = "John Smith"
+	email = "john@example.org"
+	emailText = "Email"
+	rssText = "RSS feed"
+
+	[[params.socials]]
+		url = "http://example.com"
+		text = "Social Media"
+	[[params.socials]]
+		url = "http://example.com"
+		text = "Video Series"
+

--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -9,16 +9,8 @@ tags = [
 ]
 +++
 
-Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
+Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugos-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
 <!--more-->
----
-
-## Instagram Simple Shortcode
-
-{{< instagram_simple BGvuInzyFAe hidecaption >}}
-
-<br>
-
 ---
 
 ## YouTube Privacy Enhanced Shortcode

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,3 +12,18 @@
 </ul>
 
 <p><a href="#">Back to top</a></p>
+
+<p>
+{{ if isset .Site.Params "email" }}
+<a href="mailto:{{ .Site.Params.email }}">{{ .Site.Params.emailText }}</a>
+{{ end }}
+{{ $url := "" }}
+{{ with .OutputFormats.Get "rss" -}}
+    {{ if not (eq .Permalink "") }}
+      <a href="{{ .Permalink | safeURL }}">{{ $.Site.Params.rssText }}</a>
+    {{ end }}
+{{ end -}}
+{{ range .Site.Params.socials }}
+  <a href="{{ .url | safeURL }}">{{ .text }}</a>
+{{ end }}
+</p>


### PR DESCRIPTION
Adds the footer link roadmap feature. Let me know if you would like the parameter names to be changed. I have added example parameters to `exampleSite/config.toml`. Also, I attempted to add default parameters to the `theme.toml` file but they would not show up. If you would like the footer link parameters to be in the `theme.toml` file instead of the site's `config.toml` file let me know and I will try figuring it out.